### PR TITLE
Allow spaces in parser

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -37,8 +37,8 @@ final class Parser
         $collected = [];
 
         for ($i = 0; $i < $lineCount; ++$i) {
-            if (preg_match('(^---\\s+(?P<file>\\S+))', $lines[$i], $fromMatch) &&
-                preg_match('(^\\+\\+\\+\\s+(?P<file>\\S+))', $lines[$i + 1], $toMatch)) {
+            if (preg_match('(^---\\s+(?P<file>[\\S| ]+))', $lines[$i], $fromMatch) &&
+                preg_match('(^\\+\\+\\+\\s+(?P<file>[\\S| ]+))', $lines[$i + 1], $toMatch)) {
                 if ($diff !== null) {
                     $this->parseFileDiff($diff, $collected);
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -71,6 +71,16 @@ final class ParserTest extends TestCase
         $this->assertCount(4, $chunks[2]->getLines());
     }
 
+    public function testParseWithSpacesInFileNames(): void
+    {
+        $content = FileUtils::getFileContent(__DIR__ . '/fixtures/patch3.txt');
+
+        $diffs = $this->parser->parse($content);
+
+        $this->assertEquals('a/Foo Bar.txt', $diffs[0]->getFrom());
+        $this->assertEquals('b/Foo Bar.txt', $diffs[0]->getTo());
+    }
+
     public function testParseWithRemovedLines(): void
     {
         $content = <<<END

--- a/tests/fixtures/patch3.txt
+++ b/tests/fixtures/patch3.txt
@@ -1,0 +1,9 @@
+diff --git a/Foo Bar.txt b/Foo Bar.txt
+index abcdefg..abcdefh 100644
+--- a/Foo Bar.txt
++++ b/Foo Bar.txt
+@@ -20,4 +20,5 @@ class Foo
+     const ONE = 1;
+     const TWO = 2;
++    const THREE = 3;
+     const FOUR = 4;


### PR DESCRIPTION
The from and to in diffs did not include the full path name when
spaces are being used. This change allows spaces in the file paths
as well (no tabs).